### PR TITLE
Add INA226 power monitor

### DIFF
--- a/STM32/Src/INA226_PWR_monitor.c
+++ b/STM32/Src/INA226_PWR_monitor.c
@@ -1,0 +1,90 @@
+#include "INA226_PWR_monitor.h"
+#include "i2c.h"
+
+float Voltage = 0;
+float Current = 0;
+
+
+uint16_t INA226_Read2Byte(uint8_t reg_addr)
+{
+	uint16_t reg_data=0;
+	uint16_t temp=0;
+	
+	uint8_t NumBytes = 5;
+	uint8_t buf[6] = {0};
+	
+	i2c_beginTransmission_u8(&I2C_TOUCHPAD, INA226_ADDR);
+	i2c_write_u8(&I2C_TOUCHPAD, reg_addr);
+	uint8_t res = i2c_endTransmission(&I2C_TOUCHPAD);
+	if (res == 0)
+		{
+		if (i2c_beginReceive_u8(&I2C_TOUCHPAD, INA226_ADDR))
+			{
+			reg_data = i2c_Read_Word(&I2C_TOUCHPAD);
+			i2c_stop(&I2C_TOUCHPAD);
+			}
+
+		}
+	return reg_data;
+}
+
+uint8_t INA226_Write2Byte(uint8_t reg_addr,uint16_t reg_data)
+{         
+	uint8_t data_high=(uint8_t)((reg_data&0xFF00)>>8);
+	uint8_t data_low=(uint8_t)reg_data&0x00FF;
+	
+	i2c_beginTransmission_u8(&I2C_TOUCHPAD, INA226_ADDR);
+	i2c_write_u8(&I2C_TOUCHPAD, reg_addr);
+	i2c_write_u8(&I2C_TOUCHPAD, data_high);
+	i2c_write_u8(&I2C_TOUCHPAD, data_low);
+	
+	uint8_t res = i2c_endTransmission(&I2C_TOUCHPAD);
+	
+	return res;
+}
+
+void INA226_Init(void)
+{
+	//INA226_Write2Byte(Config_Reg, 0x4527);//0100_010_100_100_111 //16 times average, 1.1ms, 1.1ms, continuous measurement of shunt voltage and bus voltage 
+	INA226_Write2Byte(Config_Reg, 0x4AD7);//0100_101_011_010_111 //256 times average, 588µs, 332µs, continuous measurement of shunt voltage and bus voltage 
+	//New VBUS data is ready every 150,5ms
+	//New VSHC (current) data is ready every 85ms
+	
+	//INA226_Write2Byte(Config_Reg, 0x4F27);//0100_111_100_100_111 //1024 times average, 1.1ms, 1.1ms, continuous measurement of shunt voltage and bus voltage 
+	//INA226_Write2Byte(Config_Reg, 0x4127);//0100_001_100_100_111 //1 times average, 1.1ms, 1.1ms, continuous measurement of shunt voltage and bus voltage 
+	
+	//Write the calibration byte (used for the current calculation)
+	INA226_Write2Byte(Calib_Reg, 0x0800);			//Current_LSB is selected 500µA R_Shunt is 5mOhm
+	//INA226_Write2Byte(Calib_Reg, 0x0A00);
+	//INA226_Write2Byte(Calib_Reg, 0x0034);
+}
+
+//Read the INA226 Voltage and Current data
+void Read_INA226_Data(void)
+{
+	#define INA226_Read_Tm 6
+	static uint8_t Rd_Count;
+	
+	Rd_Count++;
+	
+	//not ot overload the I2C bus, take the data oproximately every 210ms
+	if(Rd_Count > INA226_Read_Tm)			
+		{
+		Rd_Count = 0;
+			
+		Voltage = INA226_Read2Byte(Bus_V_Reg) * 0.00125;
+		Current = INA226_Read2Byte(Current_Reg)*CALIBRATE.INA226_CurCalc*0.001;					//multiply the Current register value with the calibration coefficient (mA/Bit)
+		}	
+}
+
+//Return the INA226 Bus Voltage
+float Get_INA226_Voltage(void)
+{
+	return Voltage;
+}
+
+//Return the INA226 Schunt Current
+float Get_INA226_Current(void)
+{
+	return Current;
+}

--- a/STM32/Src/INA226_PWR_monitor.h
+++ b/STM32/Src/INA226_PWR_monitor.h
@@ -1,0 +1,25 @@
+#ifndef __INA226_PWR_MONITOR_H
+#define __INA226_PWR_MONITOR_H
+#include "stdint.h"
+
+#define INA226_ADDR                0x40	 //A1=GND，A2=GND 
+
+#define Config_Reg                 0x00
+#define Shunt_V_Reg                0x01
+#define Bus_V_Reg                  0x02
+#define Power_Reg                  0x03
+#define Current_Reg                0x04
+#define Calib_Reg                  0x05
+#define Mask_En_Reg                0x06
+#define Alert_Reg                  0x07
+#define Man_ID_Reg                 0xFE  //0x5449
+#define ID_Reg                     0xFF  //0x2260
+
+uint16_t INA226_Read2Byte(uint8_t reg_addr);
+uint8_t INA226_Write2Byte(uint8_t reg_addr,uint16_t reg_data);
+void INA226_Init(void);
+void Read_INA226_Data(void);
+float Get_INA226_Voltage(void);
+float Get_INA226_Current(void);
+
+#endif

--- a/STM32/Src/i2c.h
+++ b/STM32/Src/i2c.h
@@ -57,6 +57,7 @@ extern void i2c_stop(I2C_DEVICE *dev);
 extern bool i2c_get_ack(I2C_DEVICE *dev);
 extern bool i2c_beginReceive_u8(I2C_DEVICE *dev, uint8_t slave_address);
 extern uint8_t i2c_Read_Byte(I2C_DEVICE *dev, uint8_t ack);
+extern uint16_t i2c_Read_Word(I2C_DEVICE *dev); 	//Tisho
 extern uint8_t i2c_endTransmission(I2C_DEVICE *dev);
 
 #endif

--- a/STM32/Src/lcd.c
+++ b/STM32/Src/lcd.c
@@ -22,6 +22,8 @@
 #include "sd.h"
 #include "vad.h"
 
+#include "INA226_PWR_monitor.h"				//Tisho
+
 volatile bool LCD_busy = false;
 volatile DEF_LCD_UpdateQuery LCD_UpdateQuery = {false};
 volatile bool LCD_systemMenuOpened = false;
@@ -1079,15 +1081,39 @@ static void LCD_displayStatusInfoBar(bool redraw)
 		sprintf(buff, "BW:FULL");
 	addSymbols(buff, buff, 12, " ", true);
 	LCDDriver_printText(buff, LAYOUT->STATUS_LABEL_BW_X_OFFSET, LAYOUT->STATUS_Y_OFFSET + LAYOUT->STATUS_LABEL_BW_Y_OFFSET, COLOR->STATUS_LABEL_BW, BG_COLOR, LAYOUT->STATUS_LABELS_FONT_SIZE);
-	//RIT
-	if (TRX.CLAR)
-		sprintf(buff, "RIT:CLAR");
-	else if (TRX.ShiftEnabled)
-		sprintf(buff, "SHIFT:%d", TRX_SHIFT);
-	else if (TRX.SplitEnabled)
-		sprintf(buff, "SPLIT:%d", TRX_SPLIT);
+	
+	//Tisho - begin of change
+	//INA226 current voltage indication 
+	#if defined(FRONTPANEL_BIG_V1)
+	if(CALIBRATE.INA226_EN)							//Is the INA226 used (installed) 
+		{
+			Read_INA226_Data();
+			sprintf(buff, "%2.1fV/%2.1fA ", Get_INA226_Voltage(), Get_INA226_Current());
+		}
 	else
-		sprintf(buff, "RIT:OFF");
+		{
+		//RIT
+		if (TRX.CLAR)
+			sprintf(buff, "RIT:CLAR");
+		else if (TRX.ShiftEnabled)
+			sprintf(buff, "SHIFT:%d", TRX_SHIFT);
+		else if (TRX.SplitEnabled)
+			sprintf(buff, "SPLIT:%d", TRX_SPLIT);
+		else
+			sprintf(buff, "RIT:OFF");
+		}
+		
+	#else
+		//RIT
+		if (TRX.CLAR)
+			sprintf(buff, "RIT:CLAR");
+		else if (TRX.ShiftEnabled)
+			sprintf(buff, "SHIFT:%d", TRX_SHIFT);
+		else if (TRX.SplitEnabled)
+			sprintf(buff, "SPLIT:%d", TRX_SPLIT);
+		else
+			sprintf(buff, "RIT:OFF");
+	#endif																		//Tisho end of change
 	addSymbols(buff, buff, 12, " ", true);
 	LCDDriver_printText(buff, LAYOUT->STATUS_LABEL_RIT_X_OFFSET, LAYOUT->STATUS_Y_OFFSET + LAYOUT->STATUS_LABEL_RIT_Y_OFFSET, COLOR->STATUS_LABEL_RIT, BG_COLOR, LAYOUT->STATUS_LABELS_FONT_SIZE);
 //THERMAL

--- a/STM32/Src/main.c
+++ b/STM32/Src/main.c
@@ -42,6 +42,7 @@
 #include "wifi.h"
 #include "images.h"
 #include "sd.h"
+#include "INA226_PWR_monitor.h"				//Tisho
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -365,6 +366,13 @@ int main(void)
   println("[OK] Digital decoder timer TIM17 init");
   HAL_TIM_Base_Start_IT(&htim17);
   println("UA3REO Transceiver started!\r\n");
+	
+	//Tisho													
+	#if defined(FRONTPANEL_BIG_V1)
+	if(CALIBRATE.INA226_EN)		//	if INA226 is activated then initialise
+		INA226_Init();
+	#endif																		//Tisho end of change
+	
   //while(true){HAL_Delay(3000); SCB->AIRCR = 0x05FA0004; } //debug restart
   /* USER CODE END 2 */
 

--- a/STM32/Src/sd.c
+++ b/STM32/Src/sd.c
@@ -1162,6 +1162,8 @@ static void SDCOMM_EXPORT_SETT_handler(void)
 			SD_WRITE_SETT_LINE("CALIBRATE.OTA_update", (uint32_t *)&CALIBRATE.OTA_update, SYSMENU_BOOLEAN);
 			SD_WRITE_SETT_LINE("CALIBRATE.TX_StartDelay", (uint32_t *)&CALIBRATE.TX_StartDelay, SYSMENU_UINT16);
 			SD_WRITE_SETT_LINE("CALIBRATE.LCD_Rotate", (uint32_t *)&CALIBRATE.LCD_Rotate, SYSMENU_BOOLEAN);
+			SD_WRITE_SETT_LINE("CALIBRATE.INA226_EN", (uint32_t *)&CALIBRATE.INA226_EN, SYSMENU_BOOLEAN);					//Tisho
+			SD_WRITE_SETT_LINE("CALIBRATE.INA226_CurCalc", (uint32_t *)&CALIBRATE.INA226_CurCalc, SYSMENU_FLOAT32);
 			SD_WRITE_SETT_LINE("CALIBRATE.PWR_VLT_Calibration", (uint32_t *)&CALIBRATE.PWR_VLT_Calibration, SYSMENU_FLOAT32);
 			//Bands settings
 			char buff[64] = {0};
@@ -1900,6 +1902,10 @@ static void SDCOMM_PARSE_SETT_LINE(char *line)
 		CALIBRATE.TX_StartDelay = uintval;
 	if (strcmp(name, "CALIBRATE.LCD_Rotate") == 0)
 		CALIBRATE.LCD_Rotate = bval;
+	if (strcmp(name, "CALIBRATE.INA226_EN") == 0)								//Tisho
+		CALIBRATE.INA226_EN = bval;
+	if (strcmp(name, "CALIBRATE.INA226_CurCalc") == 0)								
+		CALIBRATE.INA226_CurCalc = floatval;
 	if (strcmp(name, "CALIBRATE.PWR_VLT_Calibration") == 0)
 		CALIBRATE.PWR_VLT_Calibration = floatval;
 	

--- a/STM32/Src/settings.c
+++ b/STM32/Src/settings.c
@@ -582,6 +582,8 @@ void LoadCalibration(bool clear)
 		CALIBRATE.OTA_update = true;				//enable OTA FW update over WiFi
 		CALIBRATE.TX_StartDelay = 5;			//Relay switch delay before RF signal ON, ms
 		CALIBRATE.LCD_Rotate = false;			//LCD 180 degree rotation
+		CALIBRATE.INA226_EN = false;			//INA226 is not used				//Tisho
+		CALIBRATE.INA226_CurCalc = 0.4f;			//0,4mA/Bit - INA226 current calculation coeficient - dependant on the used shunt (tolerances and soldering) - Tisho
 		CALIBRATE.PWR_VLT_Calibration = 1000.0f;	//VLT meter calibration
 
 		//Default memory channels

--- a/STM32/Src/settings.h
+++ b/STM32/Src/settings.h
@@ -610,6 +610,8 @@ extern struct TRX_CALIBRATE
 	bool OTA_update;
 	uint16_t TX_StartDelay;
 	bool LCD_Rotate;
+	bool INA226_EN;												//Tisho
+	float32_t INA226_CurCalc;							//X_mA/Bit Coeficient is dependant on the used shunt (tolerances and soldering)
 	float32_t PWR_VLT_Calibration;
 	
 	BAND_SAVED_SETTINGS_TYPE MEMORY_CHANNELS[MEMORY_CHANNELS_COUNT];

--- a/STM32/Src/system_menu.c
+++ b/STM32/Src/system_menu.c
@@ -25,6 +25,7 @@
 #include "self_test.h"
 #include "cw.h"
 #include "FT8/FT8_main.h"							//Tisho
+#include "INA226_PWR_monitor.h"
 
 static void SYSMENU_HANDL_TRX_RFPower(int8_t direction);
 static void SYSMENU_HANDL_TRX_BandMap(int8_t direction);
@@ -324,6 +325,9 @@ static void SYSMENU_HANDL_CALIB_OTA_update(int8_t direction);
 static void SYSMENU_HANDL_CALIB_TX_StartDelay(int8_t direction);
 static void SYSMENU_HANDL_CALIB_PWR_VLT_Calibration(int8_t direction);
 static void SYSMENU_HANDL_CALIB_LCD_Rotate(int8_t direction);
+static void SYSMENU_HANDL_INA226_PWR_MON(int8_t direction);					//Tisho
+static void SYSMENU_HANDL_INA226_CUR_CALL(int8_t direction);
+
 
 static void SYSMENU_HANDL_TRXMENU(int8_t direction);
 static void SYSMENU_HANDL_AUDIOMENU(int8_t direction);
@@ -737,6 +741,10 @@ const static struct sysmenu_item_handler sysmenu_calibration_handlers[] =
 		{"OTA Update", SYSMENU_BOOLEAN, NULL, (uint32_t *)&CALIBRATE.OTA_update, SYSMENU_HANDL_CALIB_OTA_update},
 		{"TX Start Delay", SYSMENU_UINT16, NULL, (uint32_t *)&CALIBRATE.TX_StartDelay, SYSMENU_HANDL_CALIB_TX_StartDelay},
 		{"LCD Rotate", SYSMENU_BOOLEAN, NULL, (uint32_t *)&CALIBRATE.LCD_Rotate, SYSMENU_HANDL_CALIB_LCD_Rotate},
+		#if defined(FRONTPANEL_BIG_V1)
+		{"INA226_PWR_MON", SYSMENU_BOOLEAN, NULL, (uint32_t *)&CALIBRATE.INA226_EN, SYSMENU_HANDL_INA226_PWR_MON},		//Tisho
+		{"INA226_Cur_Calc(mA/Bit)", SYSMENU_FLOAT32, NULL, (uint32_t *)&CALIBRATE.INA226_CurCalc, SYSMENU_HANDL_INA226_CUR_CALL},		//Tisho
+		#endif	
 		{"PWR VLT Calibr", SYSMENU_FLOAT32, NULL, (uint32_t *)&CALIBRATE.PWR_VLT_Calibration, SYSMENU_HANDL_CALIB_PWR_VLT_Calibration},
 };
 
@@ -4449,6 +4457,27 @@ static void SYSMENU_HANDL_CALIB_LCD_Rotate(int8_t direction)
 	
 	LCD_Init();
 	LCD_redraw(false);
+}
+
+//Tisho
+static void SYSMENU_HANDL_INA226_PWR_MON(int8_t direction)
+{
+	if (direction > 0)
+		{
+		CALIBRATE.INA226_EN = true;
+		INA226_Init();
+		}	
+	if (direction < 0)
+		CALIBRATE.INA226_EN = false;
+}
+
+static void SYSMENU_HANDL_INA226_CUR_CALL(int8_t direction)
+{
+	CALIBRATE.INA226_CurCalc += (float32_t)direction * 0.01f;
+	if (CALIBRATE.INA226_CurCalc < 0.01f)
+		CALIBRATE.INA226_CurCalc = 0.01f;
+	if (CALIBRATE.INA226_CurCalc > 10.0f)
+		CALIBRATE.INA226_CurCalc = 10.0f;
 }
 
 static void SYSMENU_HANDL_CALIB_PWR_VLT_Calibration(int8_t direction)


### PR DESCRIPTION
INA226 allows to measure the input Voltage and Current. It is connected directly to the display touch I2C lines. The add-on is only for the 7" Display version.
In the calibration menu are added two points:
- Enable the INA226 (yes or no)
- INA226 current calibration coefficient for the current measurement (to compensate tolerances of the shunt measurement resistor)