### PR TITLE
Use slash in include file

### DIFF
--- a/STM32/Src/events.c
+++ b/STM32/Src/events.c
@@ -11,7 +11,7 @@
 #include "usbd_cat_if.h"
 #include "usbd_audio_if.h"
 #include "usbd_ua3reo.h"
-#include "FT8\FT8_main.h"
+#include "FT8/FT8_main.h"
 #include "front_unit.h"
 #include "rf_unit.h"
 #include "fpga.h"


### PR DESCRIPTION
This gets the code compile under Linux which uses slash as the path separator.